### PR TITLE
Broaden Apodex clause and split the opening sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,9 @@
 
     <section class="rise">
       <p>
-        I lead a research team working on large language models for mathematics and
-        verification at Apodex, an AI startup building deep-research agents that
-        verify each step of their reasoning. AI systems generate code and proofs faster than
+        I lead a research team at Apodex, an AI startup building agents that check
+        each step of their reasoning. My team works on large language models for
+        mathematics and verification. AI systems generate code and proofs faster than
         anyone can check them, and as generation gets cheaper, verification becomes the
         bottleneck. We work on closing that gap: models and systems that verify AI
         outputs cheaply and reliably, so the human review needed to trust them keeps


### PR DESCRIPTION
The homepage opening now reads: "I lead a research team at Apodex, an AI startup building agents that check each step of their reasoning. My team works on large language models for mathematics and verification."

- "deep-research agents" → "agents": Apodex is broader than the deep-research product
- Two sentences instead of one fixes the "…verification at Apodex" misparse and cuts the verify-repetition

🤖 Generated with [Claude Code](https://claude.com/claude-code)