### PR TITLE
Fix the Apodex description in the homepage opening

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,9 @@
 
     <section class="rise">
       <p>
-        I lead a research team at Apodex, an AI startup building agents that check
-        each step of their reasoning. My team works on large language models for
-        mathematics and verification. AI systems generate code and proofs faster than
+        I lead a research team at Apodex, an AI startup training language models
+        from scratch and building long-horizon agents for scientific discovery.
+        My team works on large language models for mathematics and verification. AI systems generate code and proofs faster than
         anyone can check them, and as generation gets cheaper, verification becomes the
         bottleneck. We work on closing that gap: models and systems that verify AI
         outputs cheaply and reliably, so the human review needed to trust them keeps


### PR DESCRIPTION
The old clause ("agents that check each step of their reasoning") misdescribed Apodex. The homepage opening now says the company trains language models from scratch and builds long-horizon agents for scientific discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)