### PR TITLE
Widen the page column to 53rem and prose to 45rem

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,16 +30,16 @@ body {
 }
 
 .page {
-  max-width: 50rem;
+  max-width: 53rem;
   margin: 0 auto;
   padding: 4.5rem 1.5rem 3rem;
 }
 
 /* the column is sized for lists and grids; running prose keeps a shorter
-   reading measure so paragraphs don't stretch past ~75 characters */
+   reading measure so paragraphs don't stretch past ~80 characters */
 section p,
 .focus li,
-.work .note { max-width: 42.5rem; }
+.work .note { max-width: 45rem; }
 
 a {
   color: var(--accent);


### PR DESCRIPTION
Slightly enlarges the site width: the column goes from 50rem to 53rem, and the prose reading measure from 42.5rem to 45rem (~80 characters per line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)